### PR TITLE
Read encoding options from command line

### DIFF
--- a/encode-libvlc.sh
+++ b/encode-libvlc.sh
@@ -29,13 +29,22 @@ URL=$1
 ID=$2
 DST=$3
 
-if [[ "$#" -eq 4 ]] ; then
+if [[ "$#" -gt 3 ]] ; then
     ENC=$4
 else
     ENC="dabplus-enc"
 fi
 
-BITRATE=80
+if [[ "$#" -gt 4 ]]; then
+    shift 4
+    OPTIONS=$@
+else
+   if [[ "$ENC" == "dabplus-enc" ]]; then
+       OPTIONS="-b 80 -r 32000"
+   else
+       OPTIONS="-b 128 -s 48 -L"
+   fi
+fi
 
 running=1
 
@@ -64,10 +73,10 @@ do
 
     printmsg "Launching encoder"
     if [[ "$ENC" == "dabplus-enc" ]] ; then
-        dabplus-enc -v "$URL" -b $BITRATE -r 32000 -o "$DST" -l &
+        dabplus-enc -v "$URL" $OPTIONS -o "$DST" -l &
         encoderpid=$!
     elif [[ "$ENC" == "toolame" ]] ; then
-        toolame -V -s 48 -L -b $BITRATE "$URL" "$DST" &
+        toolame $OPTIONS -V "$URL" "$DST" &
         encoderpid=$!
     fi
     printerr "Detected crash of encoder!"

--- a/encode-mot.sh
+++ b/encode-mot.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Encode programme using libVLC input from
+# dabplus-enc or toolame
+#
+# monitor processes, and restart if necessary
+# Optionally send an email when restart happens
+
+printerr() {
+    echo -e "\033[01;31m$1\033[0m"
+    logger -p local0.error -t "$ID" "$1"
+}
+
+printmsg() {
+    echo -e "\033[01;32m$1\033[0m"
+    logger -p local0.notice -t "$ID" "$1"
+}
+
+set -u
+
+# check number of arguments
+if [[ "$#" -lt 3 ]] ; then
+    echo "Usage $0 id options"
+    exit 1
+fi
+
+ID=$1
+shift 2
+
+OPTIONS=$@
+
+running=1
+
+encoderpid=0
+
+# The trap for Ctrl-C
+sigint_trap() {
+    printerr "Got Ctrl-C, killing mot-encoder"
+    running=0
+
+    if [[ "$encoderpid" != "0" ]] ; then
+        kill -TERM $encoderpid
+    fi
+
+    printmsg "quitting"
+    exit
+}
+
+trap sigint_trap SIGTERM
+trap sigint_trap SIGINT
+
+while [[ "$running" == "1" ]]
+do
+
+    printmsg "Launching mot-encoder"
+        mot-encoder $OPTIONS &
+        encoderpid=$!
+    printerr "Detected crash of encoder!"
+
+    sleep 5
+
+    checkloop=1
+    while [[ "$checkloop" == "1" ]]
+    do
+        sleep 2
+
+        kill -s 0 $encoderpid
+        if [[ "$?" != "0" ]] ; then
+            printerr "the mot-encoder died"
+
+            encoderpid=0
+            checkloop=0
+        fi
+    done
+
+    MAILTO=$(cat ./mail-warning.txt)
+
+    if [[ "$MAILTO" != "" ]] ; then
+        NOW=$(date)
+
+        mail -s "MOT Encoder $ID restart $URL" "$MAILTO" << EOF
+The encoder id:$ID
+encoding using mot-encoder was restarted at
+$NOW
+
+EOF
+
+    fi
+    sleep 5
+
+done
+

--- a/examplesite/configuration.sh
+++ b/examplesite/configuration.sh
@@ -13,5 +13,5 @@ declare -A radios
 radios[radio1]="./encode-libvlc.sh http://fbpc5.epfl.ch:8000/fb_192 radio1 tcp://localhost:9001"
 
 # Attenuate radio2 by 3dB
-radios[radio2]="./encode-libvlc.sh http://mp3lg.tdf-cdn.com/fip/all/fiphautdebit.mp3 radio2 tcp://localhost:9002 toolame"
+radios[radio2]="./encode-libvlc.sh http://mp3lg.tdf-cdn.com/fip/all/fiphautdebit.mp3 radio2 tcp://localhost:9002 toolame -b 128 -s 48 -m j -y 2 -L"
 

--- a/examplesite/configuration.sh
+++ b/examplesite/configuration.sh
@@ -1,17 +1,23 @@
 # Configuration file for the encoder scripts
 
-all_radios=(
-    "radio1"
-    "radio2" )
+all_radios=("radio1" "radio2" "radio3")
+all_mot=("radio1" "radio3")
 
 # declare radios to be an associative array, DO NOT REMOVE
 declare -A radios
+declare -A mot
 
 # for each radio, write here the full encoder command.
 # encode-jack needs:
 #  URL ID dabmux-URL [amplitude correction]
-radios[radio1]="./encode-libvlc.sh http://fbpc5.epfl.ch:8000/fb_192 radio1 tcp://localhost:9001"
 
-# Attenuate radio2 by 3dB
-radios[radio2]="./encode-libvlc.sh http://mp3lg.tdf-cdn.com/fip/all/fiphautdebit.mp3 radio2 tcp://localhost:9002 toolame -b 128 -s 48 -m j -y 2 -L"
+# radio1
+radios[radio1]="./encode-libvlc.sh http://radio1.aac Radio1 tcp://localhost:9001 toolame -b 128 -s 48 -m j -y 2 -L -W dls/radio1.txt -p 6 -P dls/radio1.dls"
+mot[radio]="./encode-mot.sh Radio1 --pad 6 --remove-dls --dls dls/radio1.txt --output dls/radio1.dls"
 
+# radio2
+radios[radio2]="./encode-libvlc.sh http://radio2.aac Radio2 tcp://localhost:9002 toolame -b 128 -s 48 -m j -y 2 -L"
+
+# radio3
+radios[radio3]="./encode-libvlc.sh http://radio3.aac Radio3 tcp://localhost:9003 toolame -b 128 -s 48 -m j -y 2 -L -W dls/radio3.txt -p 6 -P dls/radio3.dls"
+mot[radio3]="./encode-mot.sh Radio3 --pad 6 --remove-dls --dls dls/radio3.txt --output dls/radio3.dls"

--- a/kill-all-encoders.sh
+++ b/kill-all-encoders.sh
@@ -3,4 +3,4 @@
 # kill all processes
 
 pkill -INT "radio.sh"
-
+pkill -INT "mot.sh"

--- a/launch-all-encoders.sh
+++ b/launch-all-encoders.sh
@@ -3,18 +3,24 @@
 
 set -e
 
-if [ -f site/configuration.sh ]
+if [ -f ./configuration.sh ]
 then
 
-    source site/configuration.sh
+    source ./configuration.sh
 
     for radio in ${all_radios[*]}
     do
         echo "Launching $radio encoder"
-        screen -t "$radio" ./radio.sh "$radio"
+        screen -t "Audio Encoder $radio" ./radio.sh "$radio"
         sleep 0.4
     done
 
+    for mot in ${all_mot[*]}
+    do
+        echo "Launching $mot mot-encoder"
+        screen -t "MOT Encoder $mot" ./mot.sh "$mot"
+	sleep 0.4
+    done
 else
     echo "Error: No site configuration available!"
     exit 1

--- a/mot.sh
+++ b/mot.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Start the mot-encoder for the radio
+
+set -e
+
+source ./configuration.sh
+
+printerr() {
+    echo -e "\033[01;31m$1\033[0m"
+}
+
+printmsg() {
+    echo -e "\033[01;32m$1\033[0m"
+}
+
+script_pid=0
+sigint_trap() {
+    printerr "Got Ctrl-C, killing radio encoder script"
+    if [[ "$script_pid" != "0" ]] ; then
+        kill $script_pid
+        script_pid=0
+        wait
+    fi
+}
+
+set -e
+
+# check number of arguments
+if [[ "$#" -lt 1 ]] ; then
+    echo "Usage $0 radio-id"
+    echo "You must specify which radio to start"
+    exit 1
+fi
+
+RADIO=$1
+
+if [ "${mot[$RADIO]+_}" ] ; then
+    COMMAND=${mot[$RADIO]}
+
+    trap sigint_trap SIGINT
+
+    # execute script
+    $COMMAND &
+    script_pid=$!
+    wait
+else
+    echo "Radio $RADIO not defined in configuration"
+    exit 1
+fi
+


### PR DESCRIPTION
I've updated the script to read in the options required for toolame or dabplus-enc from
the command line, rather than relying on hard coded values.  The options should be appended to each line in the configuration.sh file.

If options aren't specified (original format configuration.sh file), then the defaults are set to the original defaults for dabenc-plus (bitrate of 80kbit/s, sample rate of 32k) and reasonable defaults for toolame (bitrate of 128kbit/s, sample rate of 48k, joint stereo mode)
