### PR TITLE
You must be root to run mmbtools-get

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The goal of this repository is to provide a:
     - Main components of the odr-mmbTools suite used in a transmission chain
     - [Supervisor](http://supervisord.org/) package
 - Simple yet functional dab configuration sample that you can adapt to your needs
-- Vagrantfile that allows you to quickly run a DAB/DAB+ ensemble through a lite debian bullseye virtual environment 
+- Vagrantfile that allows you to quickly run a DAB/DAB+ ensemble through a lite debian bullseye virtual environment
 - Docker files that allow you to quickly run a DAB/DAB+ ensemble through containers
 
 # ODR-mmbTools components
@@ -42,7 +42,7 @@ In this section:
 - **server** relates to the host where you installed the odr-mmbTools and the configuration files
 - **client** relates to any computer (including the server)
 
-After you ran the installation script on the server, point the web browser on the client to the **Supervisor web interface** on the host (http://server_address:8001). The default user name is **odr** and the default password is **odr**. Please note that this user name is not a system user profile. 
+After you ran the installation script on the server, point the web browser on the client to the **Supervisor web interface** on the host (http://server_address:8001). The default user name is **odr** and the default password is **odr**. Please note that this user name is not a system user profile.
 
 The supervisor web interface provides a graphical interface to start or stop each components of the DAB/DAB+ transmission chain: modulator, multiplexer, encoders (audio & data), encoder-manager and multiplex-manager.
 
@@ -77,7 +77,7 @@ If your hardware/virtual host is not powerful enough, then you should set the fo
 - firfilter enabled=0
 
 ### Change the transmission channel
-If channel 5A is being used in your area, you can easily switch to a [new transmission channel](http://www.wohnort.org/config/freqs.html) by applying the following command: 
+If channel 5A is being used in your area, you can easily switch to a [new transmission channel](http://www.wohnort.org/config/freqs.html) by applying the following command:
 ```
 sed -e 's/^channel=5A/^channel=a_free_channel_in_your_area/' -i $HOME/config/odr-dabmod.ini
 ```
@@ -92,6 +92,9 @@ sed -e 's/^device=driver=hackrf/^device=driver=lime/' -i $HOME/config/odr-dabmod
 
 # PlutoSDR
 sed -e 's/^device=driver=hackrf/^device=driver=plutosdr/' -i $HOME/config/odr-dabmod.ini
+
+# Blade RF
+sed -e 's/^device=driver=hackrf/^device=driver=bladerf/' -i $HOME/config/odr-dabmod.ini
 ```
 
 ### Change the transmission power setting
@@ -105,4 +108,4 @@ If you want to change the name of the multiplex, then change the label and short
 If your server is powerful enough, then you can add more services/sub-channels/components
 1. Start job **10-EncoderManager** from the Supervisor web access
 1. Point the web browser of the client to the **Encoder Manager web interface** on the host (http://server_address:8003). You can use the excellent [radio browser directory](https://www.radio-browser.info) to identify the url of the radio audio stream
-1. Modify file $HOME/config/odr-dabmux.info and adapt the services, subchannels and components in relation with the changes you made with the Encoder-Manager. You should use the values mentionned in the [official ETSI TS 101 756 document](https://www.etsi.org/deliver/etsi_ts/101700_101799/101756/02.02.01_60/ts_101756v020201p.pdf). 
+1. Modify file $HOME/config/odr-dabmux.info and adapt the services, subchannels and components in relation with the changes you made with the Encoder-Manager. You should use the values mentionned in the [official ETSI TS 101 756 document](https://www.etsi.org/deliver/etsi_ts/101700_101799/101756/02.02.01_60/ts_101756v020201p.pdf).

--- a/install/README.md
+++ b/install/README.md
@@ -44,16 +44,24 @@ If you want to quickly setup a lite clean debian environment, we suggest you use
 1. Install the ODR-mmbTools suite and the sample configuration folder
    ```
    # Install the stable version of odr-mmbTools
-   bash dab-scripts/install/mmbtools-get --branch master install
+   sudo bash dab-scripts/install/mmbtools-get --branch master install
 
    # Or install the development version of odr-mmbTools
-   bash dab-scripts/install/mmbtools-get --branch next install
+   sudo bash dab-scripts/install/mmbtools-get --branch next install
    ```
+
+### Notes
+1. You must use the argument `--odr-user` with the command **mmbtools-get** in the following 2 cases:
+	- You are not running **mmbtools-get** with `sudo`: you must thus specify the odr user profile
+	- You are running **mmbtools-get** with `sudo` and you do not want your current user to be the odr user profile
+1. **mmbtools-get** will create the user specified with `odr-user` if it does not exist:
+	- password: odr
+	- additional groups: audio,dialout
 
 # Removal
 If you wish to remove the odr-mmbTools suite and the sample configuration folder, then follow these steps:
 1. Stop all odr-mmbTools related jobs in supervisor
 2. Remove the ODR-mmbTools software suite and the configuration folder
    ```
-   bash dab-scripts/install/mmbtools-get remove
+   sudo bash dab-scripts/install/mmbtools-get remove
    ```

--- a/install/mmbtools-get
+++ b/install/mmbtools-get
@@ -17,9 +17,6 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-## CONSTANTS
-source $(realpath $(dirname $0))/mmbtools-get.conf
-
 print_usage () {
 	cat <<- EOF
 		Usage:
@@ -28,6 +25,7 @@ print_usage () {
 			Option:
 				-h, --help           Print this help
 				-b, --branch <name>  Specify the odr-mmbTools branch to use
+				--odr-user           Opendigitalradio user
 
 			Action:
 				install              Install the programs and the configuration sample
@@ -37,16 +35,30 @@ print_usage () {
 }
 
 install_base () {
+	# Create odr-user if necessary
+	if ! test $(id --user "${odr_user}"); then
+		useradd --create-home "${odr_user}"
+		echo "${odr_user}:odr" | chpasswd
+	fi
+
+  ## Add the current user to the dialout and audio groups
+  usermod --append --groups audio,dialout "${odr_user}"
+
   # Install the essential tools and create the tools root directory
-  sudo apt-get update
-  sudo apt-get install --yes build-essential automake libtool pkg-config supervisor
+  apt-get update
+  apt-get install --yes \
+		automake \
+	  build-essential \
+		libtool \
+		pkg-config \
+		supervisor
 
   if [ ! -d "${DIR_MMB}" ]; then
     mkdir "${DIR_MMB}"
   fi
 
   if [ ! $(grep inet_http_server /etc/supervisor/supervisord.conf) ]; then
-    cat << EOF | sudo tee -a /etc/supervisor/supervisord.conf > /dev/null
+    cat << EOF | tee -a /etc/supervisor/supervisord.conf > /dev/null
 
 [inet_http_server]
 port = 8001
@@ -58,7 +70,7 @@ EOF
 
 install_audioenc () {
   # Install mmb-tools: audio encoder
-  sudo apt-get install --yes \
+  apt-get install --yes \
     libasound2-dev \
     libcurl4-openssl-dev \
     libjack-jackd2-dev \
@@ -77,11 +89,11 @@ install_audioenc () {
   ./bootstrap
   ./configure --enable-alsa --enable-jack --enable-vlc --enable-gst
   make
-  sudo make install
+  make install
   make clean
   popd || return
 
-  sudo apt-get purge --yes \
+  apt-get purge --yes \
     libasound2-dev \
     libcurl4-openssl-dev \
     libjack-jackd2-dev \
@@ -89,7 +101,7 @@ install_audioenc () {
     libgstreamer-plugins-base1.0-dev \
     libvlc-dev \
     libzmq3-dev
-  sudo apt-get install --yes \
+  apt-get install --yes \
     gstreamer1.0-plugins-good \
     libasound2 \
     libcurl4 \
@@ -103,7 +115,7 @@ install_audioenc () {
 
 install_padenc () {
   # Install mmb-tools: PAD encoder
-  sudo apt-get install --yes libmagickwand-dev
+  apt-get install --yes libmagickwand-dev
 
   if [ ! -d "${DIR_PAD}" ]; then
     pushd "${DIR_MMB}" || return
@@ -115,14 +127,14 @@ install_padenc () {
   ./bootstrap
   ./configure
   make
-  sudo make install
+  make install
   make clean
   popd || return
 }
 
 install_dabmux () {
   # Install mmb-tools: dab multiplexer
-  sudo apt-get install --yes \
+  apt-get install --yes \
     libboost-system-dev \
     libcurl4-openssl-dev \
     libzmq3-dev
@@ -137,15 +149,15 @@ install_dabmux () {
   ./bootstrap.sh
   ./configure
   make
-  sudo make install
+  make install
   make clean
   popd || return
 
-  sudo apt-get purge --yes \
+  apt-get purge --yes \
     libboost-system-dev \
     libcurl4-openssl-dev \
     python3-zmq
-  sudo apt-get install --yes
+  apt-get install --yes \
     libboost-system1.74.0 \
     libcurl4 \
     libzmq5
@@ -153,7 +165,7 @@ install_dabmux () {
 
 install_dabmod () {
   # Install mmb-tools: modulator
-  sudo apt-get install --yes \
+  apt-get install --yes \
     libbladerf-dev \
     libcurl4-openssl-dev \
     libfftw3-dev \
@@ -172,11 +184,11 @@ install_dabmod () {
   ./bootstrap.sh
   ./configure CFLAGS="-O3 -DNDEBUG" CXXFLAGS="-O3 -DNDEBUG" --enable-fast-math --enable-limesdr --enable-bladerf
   make
-  sudo make install
+  make install
   make clean
   popd || return
 
-  sudo apt-get purge --yes \
+  apt-get purge --yes \
     libbladerf-dev \
     libcurl4-openssl-dev \
     libfftw3-dev \
@@ -184,7 +196,7 @@ install_dabmod () {
     libsoapysdr-dev \
     libuhd-dev \
     libzmq3-dev
-  sudo apt-get install --yes \
+  apt-get install --yes \
     libbladerf2 \
     libcurl4 \
     libfftw3-3 \
@@ -206,14 +218,14 @@ install_fdkaac () {
   ./bootstrap
   ./configure
   make
-  sudo make install
+  make install
   make clean
   popd || return
 }
 
 install_srccmp () {
   # Install mmb-tools: source companion
-  sudo apt-get install --yes \
+  apt-get install --yes \
     libzmq3-dev
 
   if [ ! -d "${DIR_SRCCMP}" ]; then
@@ -226,20 +238,20 @@ install_srccmp () {
   ./bootstrap
   ./configure
   make
-  sudo make install
+  make install
   make clean
   popd || return
 
-  sudo apt-get purge --yes \
+  apt-get purge --yes \
     libzmq3-dev
-  sudo apt-get install --yes \
+  apt-get install --yes \
     libzmq5
 
 }
 
 install_encmgr () {
   # Install mmb-tools: encoder manager
-  sudo apt-get install --yes \
+  apt-get install --yes \
     python3-cherrypy3 \
     python3-jinja2 \
     python3-pysnmp4 \
@@ -252,9 +264,6 @@ install_encmgr () {
     git clone https://github.com/Opendigitalradio/ODR-EncoderManager.git --branch "${1}"
     popd || return
   fi
-  ## Add the current user to the dialout and audio groups
-  sudo usermod --append --groups dialout $(id --user --name)
-  sudo usermod --append --groups audio $(id --user --name)
 }
 
 install_config () {
@@ -263,23 +272,23 @@ install_config () {
     rm -r "${DIR_CONFIG}"
   fi
   cp -r $(realpath $(dirname $0))/../${CONFIG_NAME} "${DIR_CONFIG}"
-  sudo ln -s "${DIR_CONFIG}"/supervisor/*.conf /etc/supervisor/conf.d/
+  ln -s "${DIR_CONFIG}"/supervisor/*.conf /etc/supervisor/conf.d/
 
   ## Adapt the supervisor configuration files
   for file in "${DIR_CONFIG}"/supervisor/*.conf; do
     [[ -e ${file} ]] || break
     sed \
-      -e "s;user=pi;user=$(id --user --name);g" \
-      -e "s;group=pi;group=$(id --group --name);g" \
-      -e "s;/home/pi;$(pwd);g" \
+      -e "s;user=pi;user=$(id --user --name ${odr_user});g" \
+      -e "s;group=pi;group=$(id --group --name ${odr_user});g" \
+      -e "s;/home/pi;/home/${odr_user};g" \
       -i "${file}"
   done
 
   ## Adapt the ODR-EncoderManager configuration file
   sed \
-    -e "s;/home/pi;$(pwd);g" \
-    -e "s;\"user\": \"pi\";\"user\": \"$(id --user --name)\";g" \
-    -e "s;\"group\": \"pi\";\"group\": \"$(id --group --name)\";g" \
+    -e "s;/home/pi;/home/${odr_user};g" \
+    -e "s;\"user\": \"pi\";\"user\": \"$(id --user --name ${odr_user})\";g" \
+    -e "s;\"group\": \"pi\";\"group\": \"$(id --group --name ${odr_user})\";g" \
     -i "${DIR_CONFIG}/encodermanager.json"
 
   ## Adapt the odr-misc.conf
@@ -288,8 +297,8 @@ install_config () {
     -i "${DIR_CONFIG}/supervisor/ODR-misc.conf"
 
   ## Restart supervisor
-  sudo supervisorctl reread
-  sudo supervisorctl reload
+  supervisorctl reread
+  supervisorctl reload
 
   echo "Sample configuration files installed"
 }
@@ -305,10 +314,12 @@ install () {
   install_srccmp "${1}"
   install_encmgr "${1}"
   install_config
-  sudo ldconfig
+  ldconfig
 
-  sudo apt-get autoremove --yes
-  sudo rm -rf /var/lib/apt/lists/*
+  chown --recursive ${odr_user}:{odr_user} /home/${odr_user}
+
+  apt-get autoremove --yes
+  rm -rf /var/lib/apt/lists/*
 
   echo "ODR-mmbTools suite and configuration files installed"
 }
@@ -316,14 +327,14 @@ install () {
 remove () {
 
   # Update supervisor
-  sudo rm /etc/supervisor/conf.d/ODR-*
-  sudo supervisorctl reread
-  sudo supervisorctl reload
+  rm /etc/supervisor/conf.d/ODR-*
+  supervisorctl reread
+  supervisorctl reload
 
   # Uninstall programs
   for makefile in $(ls ${DIR_MMB}/**/Makefile); do
     pushd $(dirname ${makefile}) || return
-    sudo make uninstall
+    make uninstall
     popd || return
   done
 
@@ -337,19 +348,33 @@ remove () {
 }
 
 # MAIN PROGRAM
+if test "$(id --user)" != "0"; then
+	echo "You must be root to run $(basename ${0})" >&2
+	exit 2
+fi
+
 branch="master"
 action=""
+odr_user="$(logname)"
 
 while [ "$#" -gt 0 ] ; do
   case "${1}" in
     (-h|--help) print_usage; exit 0 ;;
     (-b|--branch) branch="${2}" ; shift ;;
+    (--odr-user) odr_user="${2}" ; shift ;;
     install) action="install" ;;
     remove) action="remove" ;;
     *) print_usage; exit 1 ;;
   esac
   shift
 done
+
+if test -z "${odr_user}"; then
+	echo "You must use the argument --odr-user" >&2
+	exit 3
+fi
+
+source $(realpath $(dirname $0))/mmbtools-get.conf
 
 case "${action}" in
   install) install "${branch}" ;;

--- a/install/mmbtools-get
+++ b/install/mmbtools-get
@@ -27,7 +27,7 @@ print_usage () {
 
 			Option:
 				-h, --help           Print this help
-				-b, --branch <name>  Specify the odr-mmbTools branch to use 
+				-b, --branch <name>  Specify the odr-mmbTools branch to use
 
 			Action:
 				install              Install the programs and the configuration sample
@@ -145,10 +145,10 @@ install_dabmux () {
     libboost-system-dev \
     libcurl4-openssl-dev \
     python3-zmq
-  sudo apt-get install --yes 
+  sudo apt-get install --yes
     libboost-system1.74.0 \
     libcurl4 \
-    libzmq5 
+    libzmq5
 }
 
 install_dabmod () {
@@ -160,14 +160,14 @@ install_dabmod () {
     liblimesuite-dev \
     libsoapysdr-dev \
     libuhd-dev \
-    libzmq3-dev  
-  
+    libzmq3-dev
+
   if [ ! -d "${DIR_MOD}" ]; then
     pushd "${DIR_MMB}" || return
     git clone https://github.com/Opendigitalradio/ODR-DabMod.git --branch "${1}"
     popd || return
   fi
-  
+
   pushd "${DIR_MOD}" || return
   ./bootstrap.sh
   ./configure CFLAGS="-O3 -DNDEBUG" CXXFLAGS="-O3 -DNDEBUG" --enable-fast-math --enable-limesdr --enable-bladerf
@@ -183,7 +183,7 @@ install_dabmod () {
     liblimesuite-dev \
     libsoapysdr-dev \
     libuhd-dev \
-    libzmq3-dev  
+    libzmq3-dev
   sudo apt-get install --yes \
     libbladerf2 \
     libcurl4 \
@@ -201,7 +201,7 @@ install_fdkaac () {
     git clone https://github.com/Opendigitalradio/fdk-aac.git
     popd || return
   fi
-  
+
   pushd "${DIR_FDKAAC}" || return
   ./bootstrap
   ./configure
@@ -214,7 +214,7 @@ install_fdkaac () {
 install_srccmp () {
   # Install mmb-tools: source companion
   sudo apt-get install --yes \
-    libzmq3-dev  
+    libzmq3-dev
 
   if [ ! -d "${DIR_SRCCMP}" ]; then
     pushd "${DIR_MMB}" || return
@@ -231,7 +231,7 @@ install_srccmp () {
   popd || return
 
   sudo apt-get purge --yes \
-    libzmq3-dev  
+    libzmq3-dev
   sudo apt-get install --yes \
     libzmq5
 
@@ -309,7 +309,7 @@ install () {
 
   sudo apt-get autoremove --yes
   sudo rm -rf /var/lib/apt/lists/*
-  
+
   echo "ODR-mmbTools suite and configuration files installed"
 }
 

--- a/install/mmbtools-get
+++ b/install/mmbtools-get
@@ -314,7 +314,7 @@ install () {
   install_config
   ldconfig
 
-  chown --recursive ${odr_user}:{odr_user} /home/${odr_user}
+  chown --recursive ${odr_user}:${odr_user} /home/${odr_user}
 
   apt-get autoremove --yes
   rm -rf /var/lib/apt/lists/*

--- a/install/mmbtools-get
+++ b/install/mmbtools-get
@@ -155,12 +155,10 @@ install_dabmux () {
 
   apt-get purge --yes \
     libboost-system-dev \
-    libcurl4-openssl-dev \
-    python3-zmq
+    libcurl4-openssl-dev
   apt-get install --yes \
     libboost-system1.74.0 \
-    libcurl4 \
-    libzmq5
+    libcurl4
 }
 
 install_dabmod () {

--- a/install/mmbtools-get.conf
+++ b/install/mmbtools-get.conf
@@ -1,7 +1,7 @@
 # DEFINE DIRECTORIES
 CONFIG_NAME=config
-DIR_CONFIG=$(pwd)/${CONFIG_NAME}
-DIR_MMB=$(pwd)/ODR-mmbTools
+DIR_CONFIG=/home/${odr_user}/${CONFIG_NAME}
+DIR_MMB=/home/${odr_user}/ODR-mmbTools
 DIR_AUDIO=${DIR_MMB}/ODR-AudioEnc
 DIR_PAD=${DIR_MMB}/ODR-PadEnc
 DIR_MUX=${DIR_MMB}/ODR-DabMux

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,35 +1,37 @@
 # Introduction
-[Vagrant](https://www.vagrantup.com) provides easy to configure, reproducible, and portable work environments on top of virtual management software like [Virtualbox](https://www.virtualbox.org/).
+[Vagrant](https://www.vagrantup.com) provides easy to configure, reproducible, and portable work environments on top of virtual management software like Virtualbox or libvirt
 
 With Vagrant and Virtualbox, you can run the ODR-mmbTools regardless of the operating system you are using, such as Windows, MacOS, *BSD or any non-Debian Linux.
 
 # Setup
-1. Install Virtualbox
-1. Install the Virtualbox Extension pack
+1. Install one of the following virtualization engines
+	- [Virtualbox](https://www.virtualbox.org/) + Virtualbox Extension pack
+	- [libvirt](https://wiki.debian.org/Vagrant) (recommended if your host runs on linux)
 1. Install Vagrant
-1. Clone this repository or copy the Vagrantfile on your host
-1. Create and start the virtual environment. This can take quite some task since it will compile most of the mmbtools:
-    ```
-    cd directory_containing_Vagrantfile
-    vagrant up
-    ```
-1. If you have a USB transceiver:
-    - Connect the transceiver device to the physical host that runs VirtualBox
-    - Open VirtualBox and add a USB filter on the **odr-mmbtools** virtual machine
-    - Login to the **odr-mmbtools** virtual machine:
-        ```
-        vagrant ssh
-        ```
-    - Review the sections **[output]** and **[soapyoutput]** in the file $HOME/config/odr-dabmod.ini and make the necessary changes
-    - Logout from the **odr-mmbtools** virtual machine:
-        ```
-        exit
-        ```
-
-1. Restart the **odr-mmbtools** virtual machine on the physical host:
-    ```
-    vagrant reload
-    ```
+1. Connect the USB transceiver to the host that will the virtual environment
+1. Clone this repository or copy the **Vagrantfile** on your host
+1. If you are using libvirt:
+	- Change the `:vendor` and `:product` values in the **Vagrantfile**, based on the output from command `lsusb`
+1. Create and start the virtual environment. This can take quite some time since it will compile most of the mmbtools:
+	```
+	cd directory_containing_Vagrantfile
+	vagrant up
+	```
+1. If you are using Virtualbox:
+    - Open VirtualBox and add a USB filter to the virtual machine
+1. Login to the virtual machine:
+	```
+	vagrant ssh
+	```
+1. Review the sections `[output]` and `[soapyoutput]` in the file $HOME/config/odr-dabmod.ini and make the necessary changes
+1. Logout from the virtual machine:
+	```
+	exit
+	```
+1. Restart the virtual machine:
+	```
+	vagrant reload
+	```
 
 # Operations
 Here are the url to access the following web interfaces from the phyical host:

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -12,7 +12,6 @@ $script = <<-SCRIPT
 		--branch next \
 		--odr-user vagrant \
 		install
-	chown --recursive vagrant:vagrant /home/vagrant
 	SCRIPT
 
 Vagrant.configure("2") do |config|

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,6 +1,20 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+$script = <<-SCRIPT
+	apt-get update
+	apt-get install -y git
+	git clone \
+		--branch next \
+		https://github.com/opendigitalradio/dab-scripts.git \
+		/home/vagrant/dab-scripts
+	bash /home/vagrant/dab-scripts/install/mmbtools-get \
+		--branch next \
+		--odr-user vagrant \
+		install
+	chown --recursive vagrant:vagrant /home/vagrant
+	SCRIPT
+
 Vagrant.configure("2") do |config|
 	config.vm.box = "debian/bullseye64"
 
@@ -16,15 +30,9 @@ Vagrant.configure("2") do |config|
     vb.customize ['modifyvm', :id, '--usbxhci', 'on']
   end
 
-	config.vm.provision "shell", privileged: true, inline: <<-SHELL1
-		export DEBIAN_FRONTEND=noninteractive
-		apt-get update
-		apt-get install --no-install-recommends --yes git
-	SHELL1
+	config.vm.provision "shell" do |s|
+		s.env = {"DEBIAN_FRONTEND" => "noninteractive"}
+		s.inline = $script
+	end
 
-	config.vm.provision "shell", privileged: false, inline: <<-SHELL2
-		export DEBIAN_FRONTEND=noninteractive
-		git clone --branch next https://github.com/opendigitalradio/dab-scripts.git
-		bash dab-scripts/install/mmbtools-get --branch master install
-	SHELL2
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,8 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-	config.vm.box = "bento/debian-11.4"
-	config.vm.box_version = "202207.19.0"
+	config.vm.box = "debian/bullseye64"
 
   config.vm.network "forwarded_port", guest: 8001, host: 8001
   config.vm.network "forwarded_port", guest: 8002, host: 8002
@@ -24,7 +23,6 @@ Vagrant.configure("2") do |config|
 	config.vm.provision "shell", privileged: false, inline: <<-SHELL2
 		export DEBIAN_FRONTEND=noninteractive
 		git clone --branch next https://github.com/opendigitalradio/dab-scripts.git
-		bash dab-scripts/install/mmbtools-get --branch master install 
+		bash dab-scripts/install/mmbtools-get --branch master install
 	SHELL2
 end
-  

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |vb|
     vb.name = "odr-mmbtools"
+		vb.cpus = 2
+		vb.memory = 2048
     vb.customize ['modifyvm', :id, '--usbxhci', 'on']
   end
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -24,7 +24,6 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 9201, host: 9201
 
   config.vm.provider "virtualbox" do |vb|
-    vb.name = "odr-mmbtools"
 		vb.cpus = 2
 		vb.memory = 2048
     vb.customize ['modifyvm', :id, '--usbxhci', 'on']

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -29,6 +29,13 @@ Vagrant.configure("2") do |config|
     vb.customize ['modifyvm', :id, '--usbxhci', 'on']
   end
 
+	config.vm.provider :libvirt do |libvirt|
+		libvirt.cpus = 2
+		libvirt.memory = 2048
+		libvirt.usb_controller :model => "qemu-xhci"
+		libvirt.usb :vendor => '0x1d50', :product => '0x6089'
+	end
+
 	config.vm.provision "shell" do |s|
 		s.env = {"DEBIAN_FRONTEND" => "noninteractive"}
 		s.inline = $script


### PR DESCRIPTION
### Rationale
Drop the usage of `sudo`, so that **mmbtools-get** can be used to build:
- docker images inside Dockerfile
- vagrant boxes through the provisioning feature